### PR TITLE
`Games.getWindow` should be callable with no `startingAt` parameter

### DIFF
--- a/docs/classes/Client.md
+++ b/docs/classes/Client.md
@@ -1,4 +1,4 @@
-[LoL Esports API Wrapper - v0.2.3](../README.md) / [Exports](../modules.md) / Client
+[LoL Esports API Wrapper - v0.2.4](../README.md) / [Exports](../modules.md) / Client
 
 # Class: Client
 
@@ -54,7 +54,7 @@ API for live event data fetching.
 
 #### Defined in
 
-[src/client.ts:33](https://github.com/Viriatto/lol-esports-api/blob/2b06612/src/client.ts#L33)
+[src/client.ts:33](https://github.com/Viriatto/lol-esports-api/blob/1d6f598/src/client.ts#L33)
 
 ---
 
@@ -66,7 +66,7 @@ API for game related data fetching, such as fetching a game segment's data.
 
 #### Defined in
 
-[src/client.ts:54](https://github.com/Viriatto/lol-esports-api/blob/2b06612/src/client.ts#L54)
+[src/client.ts:54](https://github.com/Viriatto/lol-esports-api/blob/1d6f598/src/client.ts#L54)
 
 ---
 
@@ -78,7 +78,7 @@ API for league related data fetching, such as their schedules and tournaments.
 
 #### Defined in
 
-[src/client.ts:26](https://github.com/Viriatto/lol-esports-api/blob/2b06612/src/client.ts#L26)
+[src/client.ts:26](https://github.com/Viriatto/lol-esports-api/blob/1d6f598/src/client.ts#L26)
 
 ---
 
@@ -90,7 +90,7 @@ API for match related data fetching, such as getting a match event.
 
 #### Defined in
 
-[src/client.ts:47](https://github.com/Viriatto/lol-esports-api/blob/2b06612/src/client.ts#L47)
+[src/client.ts:47](https://github.com/Viriatto/lol-esports-api/blob/1d6f598/src/client.ts#L47)
 
 ---
 
@@ -102,7 +102,7 @@ API for team related data fetching.
 
 #### Defined in
 
-[src/client.ts:61](https://github.com/Viriatto/lol-esports-api/blob/2b06612/src/client.ts#L61)
+[src/client.ts:61](https://github.com/Viriatto/lol-esports-api/blob/1d6f598/src/client.ts#L61)
 
 ---
 
@@ -114,7 +114,7 @@ API for tournament related data fetching, such as standings and completed events
 
 #### Defined in
 
-[src/client.ts:40](https://github.com/Viriatto/lol-esports-api/blob/2b06612/src/client.ts#L40)
+[src/client.ts:40](https://github.com/Viriatto/lol-esports-api/blob/1d6f598/src/client.ts#L40)
 
 ## Accessors
 
@@ -141,7 +141,7 @@ console.log(liveEvents);
 
 #### Defined in
 
-[src/client.ts:94](https://github.com/Viriatto/lol-esports-api/blob/2b06612/src/client.ts#L94)
+[src/client.ts:94](https://github.com/Viriatto/lol-esports-api/blob/1d6f598/src/client.ts#L94)
 
 ---
 
@@ -168,7 +168,7 @@ console.log(game);
 
 #### Defined in
 
-[src/client.ts:148](https://github.com/Viriatto/lol-esports-api/blob/2b06612/src/client.ts#L148)
+[src/client.ts:148](https://github.com/Viriatto/lol-esports-api/blob/1d6f598/src/client.ts#L148)
 
 ---
 
@@ -197,7 +197,7 @@ console.log(tournaments);
 
 #### Defined in
 
-[src/client.ts:76](https://github.com/Viriatto/lol-esports-api/blob/2b06612/src/client.ts#L76)
+[src/client.ts:76](https://github.com/Viriatto/lol-esports-api/blob/1d6f598/src/client.ts#L76)
 
 ---
 
@@ -226,7 +226,7 @@ console.log(matchEventDetails);
 
 #### Defined in
 
-[src/client.ts:130](https://github.com/Viriatto/lol-esports-api/blob/2b06612/src/client.ts#L130)
+[src/client.ts:130](https://github.com/Viriatto/lol-esports-api/blob/1d6f598/src/client.ts#L130)
 
 ---
 
@@ -253,7 +253,7 @@ console.log(game);
 
 #### Defined in
 
-[src/client.ts:166](https://github.com/Viriatto/lol-esports-api/blob/2b06612/src/client.ts#L166)
+[src/client.ts:166](https://github.com/Viriatto/lol-esports-api/blob/1d6f598/src/client.ts#L166)
 
 ---
 
@@ -282,4 +282,4 @@ console.log(tournaments);
 
 #### Defined in
 
-[src/client.ts:112](https://github.com/Viriatto/lol-esports-api/blob/2b06612/src/client.ts#L112)
+[src/client.ts:112](https://github.com/Viriatto/lol-esports-api/blob/1d6f598/src/client.ts#L112)

--- a/docs/classes/internal.Events.md
+++ b/docs/classes/internal.Events.md
@@ -1,4 +1,4 @@
-[LoL Esports API Wrapper - v0.2.3](../README.md) / [Exports](../modules.md) / [internal](../modules/internal.md) / Events
+[LoL Esports API Wrapper - v0.2.4](../README.md) / [Exports](../modules.md) / [internal](../modules/internal.md) / Events
 
 # Class: Events
 
@@ -58,7 +58,7 @@ The eSports API's base URLs.
 
 #### Defined in
 
-[src/interface.ts:122](https://github.com/Viriatto/lol-esports-api/blob/2b06612/src/interface.ts#L122)
+[src/interface.ts:122](https://github.com/Viriatto/lol-esports-api/blob/1d6f598/src/interface.ts#L122)
 
 ## Methods
 
@@ -108,7 +108,7 @@ When it can't get a successfuly response from any of the endpoints built from [I
 
 #### Defined in
 
-[src/interface.ts:150](https://github.com/Viriatto/lol-esports-api/blob/2b06612/src/interface.ts#L150)
+[src/interface.ts:150](https://github.com/Viriatto/lol-esports-api/blob/1d6f598/src/interface.ts#L150)
 
 ---
 
@@ -149,4 +149,4 @@ console.log(liveEvents);
 
 #### Defined in
 
-[src/interfaces/events.ts:29](https://github.com/Viriatto/lol-esports-api/blob/2b06612/src/interfaces/events.ts#L29)
+[src/interfaces/events.ts:29](https://github.com/Viriatto/lol-esports-api/blob/1d6f598/src/interfaces/events.ts#L29)

--- a/docs/classes/internal.Games.md
+++ b/docs/classes/internal.Games.md
@@ -1,4 +1,4 @@
-[LoL Esports API Wrapper - v0.2.3](../README.md) / [Exports](../modules.md) / [internal](../modules/internal.md) / Games
+[LoL Esports API Wrapper - v0.2.4](../README.md) / [Exports](../modules.md) / [internal](../modules/internal.md) / Games
 
 # Class: Games
 
@@ -60,7 +60,7 @@ The eSports API's base URLs.
 
 #### Defined in
 
-[src/interface.ts:122](https://github.com/Viriatto/lol-esports-api/blob/2b06612/src/interface.ts#L122)
+[src/interface.ts:122](https://github.com/Viriatto/lol-esports-api/blob/1d6f598/src/interface.ts#L122)
 
 ## Methods
 
@@ -110,7 +110,7 @@ When it can't get a successfuly response from any of the endpoints built from [I
 
 #### Defined in
 
-[src/interface.ts:150](https://github.com/Viriatto/lol-esports-api/blob/2b06612/src/interface.ts#L150)
+[src/interface.ts:150](https://github.com/Viriatto/lol-esports-api/blob/1d6f598/src/interface.ts#L150)
 
 ---
 
@@ -139,7 +139,7 @@ Data about the games.
 
 #### Defined in
 
-[src/interfaces/games.ts:21](https://github.com/Viriatto/lol-esports-api/blob/2b06612/src/interfaces/games.ts#L21)
+[src/interfaces/games.ts:21](https://github.com/Viriatto/lol-esports-api/blob/1d6f598/src/interfaces/games.ts#L21)
 
 ---
 
@@ -184,22 +184,22 @@ console.log(liveEvents);
 
 #### Defined in
 
-[src/interfaces/games.ts:82](https://github.com/Viriatto/lol-esports-api/blob/2b06612/src/interfaces/games.ts#L82)
+[src/interfaces/games.ts:84](https://github.com/Viriatto/lol-esports-api/blob/1d6f598/src/interfaces/games.ts#L84)
 
 ---
 
 ### getWindow
 
-▸ **getWindow**(`gameId`, `startingAt`): `Promise`<{ `esportsGameId`: `string` ; `esportsMatchId`: `string` ; `frames`: { `rfc460Timestamp`: `string` } & { `blueTeam`: { `barons`: `number` ; `dragons`: (`"ocean"` \| `"mountain"` \| `"infernal"` \| `"cloud"` \| `"elder"`)[] ; `inhibitors`: `number` ; `participants`: { `assists`: `number` ; `creepScore`: `number` ; `deaths`: `number` ; `kills`: `number` ; `level`: `number` ; `participantId`: `1` \| `3` \| `5` \| `2` \| `4` \| `6` \| `7` \| `8` \| `9` \| `10` } & { `currentHealth`: `number` ; `maxHealth`: `number` ; `totalGold`: `number` }[] ; `totalGold`: `number` ; `totalKills`: `number` ; `towers`: `number` } ; `gameState`: `"in_game"` \| `"finished"` ; `redTeam`: { `barons`: `number` ; `dragons`: (`"ocean"` \| `"mountain"` \| `"infernal"` \| `"cloud"` \| `"elder"`)[] ; `inhibitors`: `number` ; `participants`: { `assists`: `number` ; `creepScore`: `number` ; `deaths`: `number` ; `kills`: `number` ; `level`: `number` ; `participantId`: `1` \| `3` \| `5` \| `2` \| `4` \| `6` \| `7` \| `8` \| `9` \| `10` } & { `currentHealth`: `number` ; `maxHealth`: `number` ; `totalGold`: `number` }[] ; `totalGold`: `number` ; `totalKills`: `number` ; `towers`: `number` } ; `rfc460Timestamp`: `string` }[] ; `gameMetadata`: { `blueTeamMetadata`: { `esportsTeamId`: `string` ; `participantMetadata`: ({ `championId`: `string` ; `participantId`: `1` \| `3` \| `5` \| `2` \| `4` \| `6` \| `7` \| `8` \| `9` \| `10` ; `role`: `"top"` \| `"jungle"` \| `"mid"` \| `"bottom"` \| `"support"` ; `summonerName`: `string` } \| { `championId`: `string` ; `participantId`: `1` \| `3` \| `5` \| `2` \| `4` \| `6` \| `7` \| `8` \| `9` \| `10` ; `role`: `"top"` \| `"jungle"` \| `"mid"` \| `"bottom"` \| `"support"` ; `summonerName`: `string` } & { `esportsPlayerId`: `string` })[] } ; `patchVersion`: `string` ; `redTeamMetadata`: { `esportsTeamId`: `string` ; `participantMetadata`: ({ `championId`: `string` ; `participantId`: `1` \| `3` \| `5` \| `2` \| `4` \| `6` \| `7` \| `8` \| `9` \| `10` ; `role`: `"top"` \| `"jungle"` \| `"mid"` \| `"bottom"` \| `"support"` ; `summonerName`: `string` } \| { `championId`: `string` ; `participantId`: `1` \| `3` \| `5` \| `2` \| `4` \| `6` \| `7` \| `8` \| `9` \| `10` ; `role`: `"top"` \| `"jungle"` \| `"mid"` \| `"bottom"` \| `"support"` ; `summonerName`: `string` } & { `esportsPlayerId`: `string` })[] } } }\>
+▸ **getWindow**(`gameId`, `startingAt?`): `Promise`<{ `esportsGameId`: `string` ; `esportsMatchId`: `string` ; `frames`: { `rfc460Timestamp`: `string` } & { `blueTeam`: { `barons`: `number` ; `dragons`: (`"ocean"` \| `"mountain"` \| `"infernal"` \| `"cloud"` \| `"elder"`)[] ; `inhibitors`: `number` ; `participants`: { `assists`: `number` ; `creepScore`: `number` ; `deaths`: `number` ; `kills`: `number` ; `level`: `number` ; `participantId`: `1` \| `3` \| `5` \| `2` \| `4` \| `6` \| `7` \| `8` \| `9` \| `10` } & { `currentHealth`: `number` ; `maxHealth`: `number` ; `totalGold`: `number` }[] ; `totalGold`: `number` ; `totalKills`: `number` ; `towers`: `number` } ; `gameState`: `"in_game"` \| `"finished"` ; `redTeam`: { `barons`: `number` ; `dragons`: (`"ocean"` \| `"mountain"` \| `"infernal"` \| `"cloud"` \| `"elder"`)[] ; `inhibitors`: `number` ; `participants`: { `assists`: `number` ; `creepScore`: `number` ; `deaths`: `number` ; `kills`: `number` ; `level`: `number` ; `participantId`: `1` \| `3` \| `5` \| `2` \| `4` \| `6` \| `7` \| `8` \| `9` \| `10` } & { `currentHealth`: `number` ; `maxHealth`: `number` ; `totalGold`: `number` }[] ; `totalGold`: `number` ; `totalKills`: `number` ; `towers`: `number` } ; `rfc460Timestamp`: `string` }[] ; `gameMetadata`: { `blueTeamMetadata`: { `esportsTeamId`: `string` ; `participantMetadata`: ({ `championId`: `string` ; `participantId`: `1` \| `3` \| `5` \| `2` \| `4` \| `6` \| `7` \| `8` \| `9` \| `10` ; `role`: `"top"` \| `"jungle"` \| `"mid"` \| `"bottom"` \| `"support"` ; `summonerName`: `string` } \| { `championId`: `string` ; `participantId`: `1` \| `3` \| `5` \| `2` \| `4` \| `6` \| `7` \| `8` \| `9` \| `10` ; `role`: `"top"` \| `"jungle"` \| `"mid"` \| `"bottom"` \| `"support"` ; `summonerName`: `string` } & { `esportsPlayerId`: `string` })[] } ; `patchVersion`: `string` ; `redTeamMetadata`: { `esportsTeamId`: `string` ; `participantMetadata`: ({ `championId`: `string` ; `participantId`: `1` \| `3` \| `5` \| `2` \| `4` \| `6` \| `7` \| `8` \| `9` \| `10` ; `role`: `"top"` \| `"jungle"` \| `"mid"` \| `"bottom"` \| `"support"` ; `summonerName`: `string` } \| { `championId`: `string` ; `participantId`: `1` \| `3` \| `5` \| `2` \| `4` \| `6` \| `7` \| `8` \| `9` \| `10` ; `role`: `"top"` \| `"jungle"` \| `"mid"` \| `"bottom"` \| `"support"` ; `summonerName`: `string` } & { `esportsPlayerId`: `string` })[] } } }\>
 
 Fetches overall information for a particular section of a game, such as game state, objectives taken and participants scoreboard information.
 
 #### Parameters
 
-| Name         | Type               | Description                                                                                                                          |
-| :----------- | :----------------- | :----------------------------------------------------------------------------------------------------------------------------------- |
-| `gameId`     | `string`           | -                                                                                                                                    |
-| `startingAt` | `string` \| `Date` | The starting date of the segment to fetch from the game. If it is later than the end date of the game, retrieves the last 10 frames. |
+| Name          | Type               | Description                                                                                                                                                                                   |
+| :------------ | :----------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `gameId`      | `string`           | -                                                                                                                                                                                             |
+| `startingAt?` | `string` \| `Date` | The starting date of the segment to fetch from the game. If it is later than the end date of the game, retrieves the last 10 frames. If `undefined`, returns the first 10 frames of the game. |
 
 #### Returns
 
@@ -217,4 +217,4 @@ The response's data contains a `frames` array property which includes "snapshots
 
 #### Defined in
 
-[src/interfaces/games.ts:43](https://github.com/Viriatto/lol-esports-api/blob/2b06612/src/interfaces/games.ts#L43)
+[src/interfaces/games.ts:44](https://github.com/Viriatto/lol-esports-api/blob/1d6f598/src/interfaces/games.ts#L44)

--- a/docs/classes/internal.Interface.md
+++ b/docs/classes/internal.Interface.md
@@ -1,4 +1,4 @@
-[LoL Esports API Wrapper - v0.2.3](../README.md) / [Exports](../modules.md) / [internal](../modules/internal.md) / Interface
+[LoL Esports API Wrapper - v0.2.4](../README.md) / [Exports](../modules.md) / [internal](../modules/internal.md) / Interface
 
 # Class: Interface
 
@@ -59,7 +59,7 @@ The eSports API's base URLs.
 
 #### Defined in
 
-[src/interface.ts:122](https://github.com/Viriatto/lol-esports-api/blob/2b06612/src/interface.ts#L122)
+[src/interface.ts:122](https://github.com/Viriatto/lol-esports-api/blob/1d6f598/src/interface.ts#L122)
 
 ## Methods
 
@@ -105,4 +105,4 @@ When it can't get a successfuly response from any of the endpoints built from [I
 
 #### Defined in
 
-[src/interface.ts:150](https://github.com/Viriatto/lol-esports-api/blob/2b06612/src/interface.ts#L150)
+[src/interface.ts:150](https://github.com/Viriatto/lol-esports-api/blob/1d6f598/src/interface.ts#L150)

--- a/docs/classes/internal.Leagues.md
+++ b/docs/classes/internal.Leagues.md
@@ -1,4 +1,4 @@
-[LoL Esports API Wrapper - v0.2.3](../README.md) / [Exports](../modules.md) / [internal](../modules/internal.md) / Leagues
+[LoL Esports API Wrapper - v0.2.4](../README.md) / [Exports](../modules.md) / [internal](../modules/internal.md) / Leagues
 
 # Class: Leagues
 
@@ -60,7 +60,7 @@ The eSports API's base URLs.
 
 #### Defined in
 
-[src/interface.ts:122](https://github.com/Viriatto/lol-esports-api/blob/2b06612/src/interface.ts#L122)
+[src/interface.ts:122](https://github.com/Viriatto/lol-esports-api/blob/1d6f598/src/interface.ts#L122)
 
 ## Methods
 
@@ -110,7 +110,7 @@ When it can't get a successfuly response from any of the endpoints built from [I
 
 #### Defined in
 
-[src/interface.ts:150](https://github.com/Viriatto/lol-esports-api/blob/2b06612/src/interface.ts#L150)
+[src/interface.ts:150](https://github.com/Viriatto/lol-esports-api/blob/1d6f598/src/interface.ts#L150)
 
 ---
 
@@ -138,7 +138,7 @@ Data about all leagues.
 
 #### Defined in
 
-[src/interfaces/leagues.ts:20](https://github.com/Viriatto/lol-esports-api/blob/2b06612/src/interfaces/leagues.ts#L20)
+[src/interfaces/leagues.ts:20](https://github.com/Viriatto/lol-esports-api/blob/1d6f598/src/interfaces/leagues.ts#L20)
 
 ---
 
@@ -168,7 +168,7 @@ Data on all tournaments from a specific league.
 
 #### Defined in
 
-[src/interfaces/leagues.ts:60](https://github.com/Viriatto/lol-esports-api/blob/2b06612/src/interfaces/leagues.ts#L60)
+[src/interfaces/leagues.ts:60](https://github.com/Viriatto/lol-esports-api/blob/1d6f598/src/interfaces/leagues.ts#L60)
 
 ---
 
@@ -197,4 +197,4 @@ Data on all tournaments from a specific league.
 
 #### Defined in
 
-[src/interfaces/leagues.ts:39](https://github.com/Viriatto/lol-esports-api/blob/2b06612/src/interfaces/leagues.ts#L39)
+[src/interfaces/leagues.ts:39](https://github.com/Viriatto/lol-esports-api/blob/1d6f598/src/interfaces/leagues.ts#L39)

--- a/docs/classes/internal.Matches.md
+++ b/docs/classes/internal.Matches.md
@@ -1,4 +1,4 @@
-[LoL Esports API Wrapper - v0.2.3](../README.md) / [Exports](../modules.md) / [internal](../modules/internal.md) / Matches
+[LoL Esports API Wrapper - v0.2.4](../README.md) / [Exports](../modules.md) / [internal](../modules/internal.md) / Matches
 
 # Class: Matches
 
@@ -58,7 +58,7 @@ The eSports API's base URLs.
 
 #### Defined in
 
-[src/interface.ts:122](https://github.com/Viriatto/lol-esports-api/blob/2b06612/src/interface.ts#L122)
+[src/interface.ts:122](https://github.com/Viriatto/lol-esports-api/blob/1d6f598/src/interface.ts#L122)
 
 ## Methods
 
@@ -108,7 +108,7 @@ When it can't get a successfuly response from any of the endpoints built from [I
 
 #### Defined in
 
-[src/interface.ts:150](https://github.com/Viriatto/lol-esports-api/blob/2b06612/src/interface.ts#L150)
+[src/interface.ts:150](https://github.com/Viriatto/lol-esports-api/blob/1d6f598/src/interface.ts#L150)
 
 ---
 
@@ -137,4 +137,4 @@ Data on the event details of a particular match.
 
 #### Defined in
 
-[src/interfaces/matches.ts:20](https://github.com/Viriatto/lol-esports-api/blob/2b06612/src/interfaces/matches.ts#L20)
+[src/interfaces/matches.ts:20](https://github.com/Viriatto/lol-esports-api/blob/1d6f598/src/interfaces/matches.ts#L20)

--- a/docs/classes/internal.Teams.md
+++ b/docs/classes/internal.Teams.md
@@ -1,4 +1,4 @@
-[LoL Esports API Wrapper - v0.2.3](../README.md) / [Exports](../modules.md) / [internal](../modules/internal.md) / Teams
+[LoL Esports API Wrapper - v0.2.4](../README.md) / [Exports](../modules.md) / [internal](../modules/internal.md) / Teams
 
 # Class: Teams
 
@@ -58,7 +58,7 @@ The eSports API's base URLs.
 
 #### Defined in
 
-[src/interface.ts:122](https://github.com/Viriatto/lol-esports-api/blob/2b06612/src/interface.ts#L122)
+[src/interface.ts:122](https://github.com/Viriatto/lol-esports-api/blob/1d6f598/src/interface.ts#L122)
 
 ## Methods
 
@@ -108,7 +108,7 @@ When it can't get a successfuly response from any of the endpoints built from [I
 
 #### Defined in
 
-[src/interface.ts:150](https://github.com/Viriatto/lol-esports-api/blob/2b06612/src/interface.ts#L150)
+[src/interface.ts:150](https://github.com/Viriatto/lol-esports-api/blob/1d6f598/src/interface.ts#L150)
 
 ---
 
@@ -141,4 +141,4 @@ If `teamId` is undefined, fetches data for all teams.
 
 #### Defined in
 
-[src/interfaces/teams.ts:23](https://github.com/Viriatto/lol-esports-api/blob/2b06612/src/interfaces/teams.ts#L23)
+[src/interfaces/teams.ts:23](https://github.com/Viriatto/lol-esports-api/blob/1d6f598/src/interfaces/teams.ts#L23)

--- a/docs/classes/internal.Tournaments.md
+++ b/docs/classes/internal.Tournaments.md
@@ -1,4 +1,4 @@
-[LoL Esports API Wrapper - v0.2.3](../README.md) / [Exports](../modules.md) / [internal](../modules/internal.md) / Tournaments
+[LoL Esports API Wrapper - v0.2.4](../README.md) / [Exports](../modules.md) / [internal](../modules/internal.md) / Tournaments
 
 # Class: Tournaments
 
@@ -59,7 +59,7 @@ The eSports API's base URLs.
 
 #### Defined in
 
-[src/interface.ts:122](https://github.com/Viriatto/lol-esports-api/blob/2b06612/src/interface.ts#L122)
+[src/interface.ts:122](https://github.com/Viriatto/lol-esports-api/blob/1d6f598/src/interface.ts#L122)
 
 ## Methods
 
@@ -109,7 +109,7 @@ When it can't get a successfuly response from any of the endpoints built from [I
 
 #### Defined in
 
-[src/interface.ts:150](https://github.com/Viriatto/lol-esports-api/blob/2b06612/src/interface.ts#L150)
+[src/interface.ts:150](https://github.com/Viriatto/lol-esports-api/blob/1d6f598/src/interface.ts#L150)
 
 ---
 
@@ -142,7 +142,7 @@ If `tournamentIdOrIds` is `undefined`, pulls data for all tournaments.
 
 #### Defined in
 
-[src/interfaces/tournaments.ts:24](https://github.com/Viriatto/lol-esports-api/blob/2b06612/src/interfaces/tournaments.ts#L24)
+[src/interfaces/tournaments.ts:24](https://github.com/Viriatto/lol-esports-api/blob/1d6f598/src/interfaces/tournaments.ts#L24)
 
 ---
 
@@ -171,4 +171,4 @@ Data on the completed events of a particular tournament.
 
 #### Defined in
 
-[src/interfaces/tournaments.ts:47](https://github.com/Viriatto/lol-esports-api/blob/2b06612/src/interfaces/tournaments.ts#L47)
+[src/interfaces/tournaments.ts:47](https://github.com/Viriatto/lol-esports-api/blob/1d6f598/src/interfaces/tournaments.ts#L47)

--- a/docs/interfaces/internal.components.md
+++ b/docs/interfaces/internal.components.md
@@ -1,4 +1,4 @@
-[LoL Esports API Wrapper - v0.2.3](../README.md) / [Exports](../modules.md) / [internal](../modules/internal.md) / components
+[LoL Esports API Wrapper - v0.2.4](../README.md) / [Exports](../modules.md) / [internal](../modules/internal.md) / components
 
 # Interface: components
 
@@ -23,7 +23,7 @@
 
 #### Defined in
 
-[src/api-types.ts:1132](https://github.com/Viriatto/lol-esports-api/blob/2b06612/src/api-types.ts#L1132)
+[src/api-types.ts:1132](https://github.com/Viriatto/lol-esports-api/blob/1d6f598/src/api-types.ts#L1132)
 
 ---
 
@@ -53,7 +53,7 @@
 
 #### Defined in
 
-[src/api-types.ts:1089](https://github.com/Viriatto/lol-esports-api/blob/2b06612/src/api-types.ts#L1089)
+[src/api-types.ts:1089](https://github.com/Viriatto/lol-esports-api/blob/1d6f598/src/api-types.ts#L1089)
 
 ---
 
@@ -63,7 +63,7 @@
 
 #### Defined in
 
-[src/api-types.ts:1133](https://github.com/Viriatto/lol-esports-api/blob/2b06612/src/api-types.ts#L1133)
+[src/api-types.ts:1133](https://github.com/Viriatto/lol-esports-api/blob/1d6f598/src/api-types.ts#L1133)
 
 ---
 
@@ -73,7 +73,7 @@
 
 #### Defined in
 
-[src/api-types.ts:1131](https://github.com/Viriatto/lol-esports-api/blob/2b06612/src/api-types.ts#L1131)
+[src/api-types.ts:1131](https://github.com/Viriatto/lol-esports-api/blob/1d6f598/src/api-types.ts#L1131)
 
 ---
 
@@ -83,7 +83,7 @@
 
 #### Defined in
 
-[src/api-types.ts:1088](https://github.com/Viriatto/lol-esports-api/blob/2b06612/src/api-types.ts#L1088)
+[src/api-types.ts:1088](https://github.com/Viriatto/lol-esports-api/blob/1d6f598/src/api-types.ts#L1088)
 
 ---
 
@@ -467,4 +467,4 @@
 
 #### Defined in
 
-[src/api-types.ts:98](https://github.com/Viriatto/lol-esports-api/blob/2b06612/src/api-types.ts#L98)
+[src/api-types.ts:98](https://github.com/Viriatto/lol-esports-api/blob/1d6f598/src/api-types.ts#L98)

--- a/docs/interfaces/internal.paths.md
+++ b/docs/interfaces/internal.paths.md
@@ -1,4 +1,4 @@
-[LoL Esports API Wrapper - v0.2.3](../README.md) / [Exports](../modules.md) / [internal](../modules/internal.md) / paths
+[LoL Esports API Wrapper - v0.2.4](../README.md) / [Exports](../modules.md) / [internal](../modules/internal.md) / paths
 
 # Interface: paths
 
@@ -52,7 +52,7 @@
 
 #### Defined in
 
-[src/api-types.ts:48](https://github.com/Viriatto/lol-esports-api/blob/2b06612/src/api-types.ts#L48)
+[src/api-types.ts:48](https://github.com/Viriatto/lol-esports-api/blob/1d6f598/src/api-types.ts#L48)
 
 ---
 
@@ -79,7 +79,7 @@
 
 #### Defined in
 
-[src/api-types.ts:33](https://github.com/Viriatto/lol-esports-api/blob/2b06612/src/api-types.ts#L33)
+[src/api-types.ts:33](https://github.com/Viriatto/lol-esports-api/blob/1d6f598/src/api-types.ts#L33)
 
 ---
 
@@ -105,7 +105,7 @@
 
 #### Defined in
 
-[src/api-types.ts:36](https://github.com/Viriatto/lol-esports-api/blob/2b06612/src/api-types.ts#L36)
+[src/api-types.ts:36](https://github.com/Viriatto/lol-esports-api/blob/1d6f598/src/api-types.ts#L36)
 
 ---
 
@@ -131,7 +131,7 @@
 
 #### Defined in
 
-[src/api-types.ts:42](https://github.com/Viriatto/lol-esports-api/blob/2b06612/src/api-types.ts#L42)
+[src/api-types.ts:42](https://github.com/Viriatto/lol-esports-api/blob/1d6f598/src/api-types.ts#L42)
 
 ---
 
@@ -156,7 +156,7 @@
 
 #### Defined in
 
-[src/api-types.ts:18](https://github.com/Viriatto/lol-esports-api/blob/2b06612/src/api-types.ts#L18)
+[src/api-types.ts:18](https://github.com/Viriatto/lol-esports-api/blob/1d6f598/src/api-types.ts#L18)
 
 ---
 
@@ -182,7 +182,7 @@
 
 #### Defined in
 
-[src/api-types.ts:24](https://github.com/Viriatto/lol-esports-api/blob/2b06612/src/api-types.ts#L24)
+[src/api-types.ts:24](https://github.com/Viriatto/lol-esports-api/blob/1d6f598/src/api-types.ts#L24)
 
 ---
 
@@ -214,7 +214,7 @@
 
 #### Defined in
 
-[src/api-types.ts:21](https://github.com/Viriatto/lol-esports-api/blob/2b06612/src/api-types.ts#L21)
+[src/api-types.ts:21](https://github.com/Viriatto/lol-esports-api/blob/1d6f598/src/api-types.ts#L21)
 
 ---
 
@@ -240,7 +240,7 @@
 
 #### Defined in
 
-[src/api-types.ts:30](https://github.com/Viriatto/lol-esports-api/blob/2b06612/src/api-types.ts#L30)
+[src/api-types.ts:30](https://github.com/Viriatto/lol-esports-api/blob/1d6f598/src/api-types.ts#L30)
 
 ---
 
@@ -266,7 +266,7 @@
 
 #### Defined in
 
-[src/api-types.ts:39](https://github.com/Viriatto/lol-esports-api/blob/2b06612/src/api-types.ts#L39)
+[src/api-types.ts:39](https://github.com/Viriatto/lol-esports-api/blob/1d6f598/src/api-types.ts#L39)
 
 ---
 
@@ -292,7 +292,7 @@
 
 #### Defined in
 
-[src/api-types.ts:27](https://github.com/Viriatto/lol-esports-api/blob/2b06612/src/api-types.ts#L27)
+[src/api-types.ts:27](https://github.com/Viriatto/lol-esports-api/blob/1d6f598/src/api-types.ts#L27)
 
 ---
 
@@ -321,7 +321,7 @@
 
 #### Defined in
 
-[src/api-types.ts:69](https://github.com/Viriatto/lol-esports-api/blob/2b06612/src/api-types.ts#L69)
+[src/api-types.ts:69](https://github.com/Viriatto/lol-esports-api/blob/1d6f598/src/api-types.ts#L69)
 
 ---
 
@@ -353,7 +353,7 @@
 
 #### Defined in
 
-[src/api-types.ts:73](https://github.com/Viriatto/lol-esports-api/blob/2b06612/src/api-types.ts#L73)
+[src/api-types.ts:73](https://github.com/Viriatto/lol-esports-api/blob/1d6f598/src/api-types.ts#L73)
 
 ---
 
@@ -375,7 +375,7 @@
 
 #### Defined in
 
-[src/api-types.ts:51](https://github.com/Viriatto/lol-esports-api/blob/2b06612/src/api-types.ts#L51)
+[src/api-types.ts:51](https://github.com/Viriatto/lol-esports-api/blob/1d6f598/src/api-types.ts#L51)
 
 ---
 
@@ -405,7 +405,7 @@
 
 #### Defined in
 
-[src/api-types.ts:86](https://github.com/Viriatto/lol-esports-api/blob/2b06612/src/api-types.ts#L86)
+[src/api-types.ts:86](https://github.com/Viriatto/lol-esports-api/blob/1d6f598/src/api-types.ts#L86)
 
 ---
 
@@ -433,7 +433,7 @@
 
 #### Defined in
 
-[src/api-types.ts:76](https://github.com/Viriatto/lol-esports-api/blob/2b06612/src/api-types.ts#L76)
+[src/api-types.ts:76](https://github.com/Viriatto/lol-esports-api/blob/1d6f598/src/api-types.ts#L76)
 
 ---
 
@@ -464,7 +464,7 @@
 
 #### Defined in
 
-[src/api-types.ts:79](https://github.com/Viriatto/lol-esports-api/blob/2b06612/src/api-types.ts#L79)
+[src/api-types.ts:79](https://github.com/Viriatto/lol-esports-api/blob/1d6f598/src/api-types.ts#L79)
 
 ---
 
@@ -485,7 +485,7 @@
 
 #### Defined in
 
-[src/api-types.ts:54](https://github.com/Viriatto/lol-esports-api/blob/2b06612/src/api-types.ts#L54)
+[src/api-types.ts:54](https://github.com/Viriatto/lol-esports-api/blob/1d6f598/src/api-types.ts#L54)
 
 ---
 
@@ -521,4 +521,4 @@
 
 #### Defined in
 
-[src/api-types.ts:45](https://github.com/Viriatto/lol-esports-api/blob/2b06612/src/api-types.ts#L45)
+[src/api-types.ts:45](https://github.com/Viriatto/lol-esports-api/blob/1d6f598/src/api-types.ts#L45)

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -1,6 +1,6 @@
-[LoL Esports API Wrapper - v0.2.3](README.md) / Exports
+[LoL Esports API Wrapper - v0.2.4](README.md) / Exports
 
-# LoL Esports API Wrapper - v0.2.3
+# LoL Esports API Wrapper - v0.2.4
 
 ## Table of contents
 

--- a/docs/modules/internal.md
+++ b/docs/modules/internal.md
@@ -1,4 +1,4 @@
-[LoL Esports API Wrapper - v0.2.3](../README.md) / [Exports](../modules.md) / internal
+[LoL Esports API Wrapper - v0.2.4](../README.md) / [Exports](../modules.md) / internal
 
 # Module: internal
 
@@ -50,7 +50,7 @@ Searches for an existing type within the eSports API types, if it does not exist
 
 #### Defined in
 
-[src/interface.ts:76](https://github.com/Viriatto/lol-esports-api/blob/2b06612/src/interface.ts#L76)
+[src/interface.ts:76](https://github.com/Viriatto/lol-esports-api/blob/1d6f598/src/interface.ts#L76)
 
 ---
 
@@ -62,7 +62,7 @@ The API endpoints as per [vickz84259's specification](https://vickz84259.github.
 
 #### Defined in
 
-[src/interface.ts:58](https://github.com/Viriatto/lol-esports-api/blob/2b06612/src/interface.ts#L58)
+[src/interface.ts:58](https://github.com/Viriatto/lol-esports-api/blob/1d6f598/src/interface.ts#L58)
 
 ---
 
@@ -74,7 +74,7 @@ The API endpoints as per [vickz84259's specification](https://vickz84259.github.
 
 #### Defined in
 
-[src/interface.ts:91](https://github.com/Viriatto/lol-esports-api/blob/2b06612/src/interface.ts#L91)
+[src/interface.ts:91](https://github.com/Viriatto/lol-esports-api/blob/1d6f598/src/interface.ts#L91)
 
 ---
 
@@ -92,7 +92,7 @@ The API endpoint operations as per [vickz84259's specification](https://vickz842
 
 #### Defined in
 
-[src/interface.ts:65](https://github.com/Viriatto/lol-esports-api/blob/2b06612/src/interface.ts#L65)
+[src/interface.ts:65](https://github.com/Viriatto/lol-esports-api/blob/1d6f598/src/interface.ts#L65)
 
 ---
 
@@ -114,7 +114,7 @@ The eSports API specification used here is a fork of [vickz84259's work](https:/
 
 #### Defined in
 
-[src/interface.ts:50](https://github.com/Viriatto/lol-esports-api/blob/2b06612/src/interface.ts#L50)
+[src/interface.ts:50](https://github.com/Viriatto/lol-esports-api/blob/1d6f598/src/interface.ts#L50)
 
 ---
 
@@ -171,4 +171,4 @@ OneOf type helpers
 
 #### Defined in
 
-[src/api-types.ts:7](https://github.com/Viriatto/lol-esports-api/blob/2b06612/src/api-types.ts#L7)
+[src/api-types.ts:7](https://github.com/Viriatto/lol-esports-api/blob/1d6f598/src/api-types.ts#L7)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@viriato/lol-esports-api",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@viriato/lol-esports-api",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "license": "ISC",
       "dependencies": {
         "axios": "^1.5.1"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@viriato/lol-esports-api",
   "type": "module",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Implementation of League of Legends' Unofficial Esports API.",
   "main": "./dist/index.js",
   "types": "./types/index.d.ts",

--- a/src/interfaces/games.ts
+++ b/src/interfaces/games.ts
@@ -34,19 +34,21 @@ export default class Games extends Interface {
    * The response's data contains a `frames` array property which includes "snapshots" of game states for a time span of 10 seconds.
    *
    * @param startingAt - The starting date of the segment to fetch from the game. If it is later than the end date of the game, retrieves the last 10 frames.
+   * If `undefined`, returns the first 10 frames of the game.
    * @returns Data on a segment of the game.
    *
    * @see {@link https://vickz84259.github.io/lolesports-api-docs/#operation/getGames | vickz84259's endpoint documentation}.
    *
    * @public @sealed
    */
-  public async getWindow(gameId: string, startingAt: string | Date) {
+  public async getWindow(gameId: string, startingAt?: string | Date) {
     return this._get(this._baseURLs.feed, "/window/{gameId}", {
       query: {
-        startingTime:
-          typeof startingAt === "string"
+        startingTime: startingAt
+          ? typeof startingAt === "string"
             ? startingAt
-            : startingAt.toISOString(),
+            : startingAt.toISOString()
+          : undefined,
       },
       path: {
         gameId,


### PR DESCRIPTION
Calling this method without a `startingAt` parameter returns the first 10 frames of the game.